### PR TITLE
Add manifest for deploying the controller

### DIFF
--- a/artifacts/deployment/README.md
+++ b/artifacts/deployment/README.md
@@ -1,0 +1,26 @@
+# `EtcdProxyController` manifest
+
+This directory contains manifest for deploying the `EtcdProxyController` in the cluster. It creates the following resources:
+* **namespace/kube-apiserver-storage** - namespace where controller and resources managed by controller are deployed.
+* **serviceaccount/etcdproxy-controller-sa** - ServiceAccount used by Controller for managing EtcdStorage objects, ReplicaSets and Services.
+* **serviceaccount/etcdproxy-sa** - ServiceAccount used by EtcdProxy Pods.
+* **clusterrole/etcdproxy-crd-clusterrole** - ClusterRole allowing **etcdproxy-controller-sa** ServiceAccount to update EtcdStorage status.
+* **role/etcdproxy-controller-role** - Role allowing **etcdproxy-controller-sa** ServiceAccount to manage ReplicaSets, Services, ConfigMap and Secrets in the **kube-apiserver-storage** namespace.
+* **clusterrolebinding/etcdproxy-crd-clusterrolebinding** - Binds **clusterrole/etcdproxy-crd-clusterrole** to **serviceaccount/etcdproxy-controller-sa**.
+* **rolebinding/etcdproxy-controller-rolebinding** - Binds **role/etcdproxy-controller-role** to **serviceaccount/etcdproxy-controller-sa**.
+* **customresourcedefinition/etcdstorages.etcd.xmudrii.com** - EtcdStorage CRD used to manage etcd proxies.
+* **deployment/etcdproxy-controller-deployment** - Deployment for the `EtcdProxyController`.
+
+## RBAC Rules
+
+The **clusterrole/etcdproxy-crd-clusterrole** allows controller to get the EtcdStorage instances and update to the Status.
+The role is supposed to be bound to the Controller's ServiceAccount.
+
+The **role/etcdproxy-controller-role** ensures Controller can manage resources used by the controller (ReplicaSets, Services, ConfigMaps, Secrets). The role is supposed to be bound to the Controller's Service Account.
+
+## Discovering the core `etcd`
+
+The deployment manifest assumes:
+* The core `etcd` is available on the `https://etcd-svc-1.etcd.svc:2379` URL. To modify it, change the command in the Deployment object (`-etcd-core-url` flag).
+* The CA certificate for the core etcd is stored in the ConfigMap called `etcd-coreserving-ca`, in the controller's namespace. This can be configured using the `-etcd-core-ca-configmap` flag which takes the name of the ConfigMap, in the controller's namespace.
+* The client certificate and key for the core etcd are stored in the Secret called `etcd-coreserving-cert`, in the controller's namespace. This can be configured using the `-etcd-core-certs-secret` flag which takes the name of the Secret, in the controller's namespace.

--- a/artifacts/deployment/etcdproxy-controller.yaml
+++ b/artifacts/deployment/etcdproxy-controller.yaml
@@ -1,0 +1,121 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-apiserver-storage
+spec:
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcdproxy-sa
+  namespace: kube-apiserver-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcdproxy-crd-clusterrole
+rules:
+- apiGroups: ["etcd.xmudrii.com"]
+  resources: ["etcdstorages"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["etcd.xmudrii.com"]
+  resources: ["etcdstorages/status"]
+  verbs: ["get", "watch", "list", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcdproxy-role
+  namespace: kube-apiserver-storage
+rules:
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["etcd-coreserving-cert"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["etcd-coreserving-ca"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcdproxy-crd-clusterrolebinding
+subjects:
+- kind: ServiceAccount
+  name: etcdproxy-sa # Name is case sensitive
+  namespace: kube-apiserver-storage
+roleRef:
+  kind: ClusterRole #this must be Role or ClusterRole
+  name: etcdproxy-crd-clusterrole # this must match the name of the Role or ClusterRole you wish to bind to
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcdproxy-rolebinding
+  namespace: kube-apiserver-storage
+subjects:
+- kind: ServiceAccount
+  name: etcdproxy-sa # Name is case sensitive
+  namespace: kube-apiserver-storage
+roleRef:
+  kind: Role #this must be Role or ClusterRole
+  name: etcdproxy-role # this must match the name of the Role or ClusterRole you wish to bind to
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdstorages.etcd.xmudrii.com
+spec:
+  group: etcd.xmudrii.com
+  version: v1alpha1
+  names:
+    kind: EtcdStorage
+    plural: etcdstorages
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        metadata:
+          properties:
+            name:
+              type: string
+              maxLength: 59 # because of service name, explained above.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcdproxy-controller-deployment
+  namespace: kube-apiserver-storage
+  labels:
+    controller: etcdproxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      controller: etcdproxy
+  template:
+    metadata:
+      labels:
+        controller: etcdproxy
+    spec:
+      serviceAccountName: etcdproxy-sa
+      containers:
+      - name: etcdproxy-controller
+        image: xmudrii/etcdproxy-controller:latest
+        command:
+          - /etcdproxy-controller
+          - "-etcd-core-url=https://etcd-svc-1.etcd.svc:2379"
+        imagePullPolicy: Always

--- a/artifacts/deployment/etcdproxy-controller.yaml
+++ b/artifacts/deployment/etcdproxy-controller.yaml
@@ -1,16 +1,26 @@
 ---
+# The Namespace where controller and controller resources are deployed.
 apiVersion: v1
 kind: Namespace
 metadata:
   name: kube-apiserver-storage
 spec:
 ---
+# The ServiceAccount used by EtcdProxyController.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcdproxy-controller-sa
+  namespace: kube-apiserver-storage
+---
+# The ServiceAccount used by EtcdProxy pods.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: etcdproxy-sa
   namespace: kube-apiserver-storage
 ---
+# ClusterRole for etcdproxy-controller-sa to get EtcdStorages and update status.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -21,12 +31,13 @@ rules:
   verbs: ["get", "watch", "list"]
 - apiGroups: ["etcd.xmudrii.com"]
   resources: ["etcdstorages/status"]
-  verbs: ["get", "watch", "list", "create", "update", "patch"]
+  verbs: ["update", "patch"]
 ---
+# Role for etcdproxy-controller-sa to manage ReplicaSets, Services, ConfigMap and Secrets.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: etcdproxy-role
+  name: etcdproxy-controller-role
   namespace: kube-apiserver-storage
 rules:
 - apiGroups: ["apps"]
@@ -38,42 +49,37 @@ rules:
 - apiGroups: [""]
   resources: ["secrets", "configmaps"]
   verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  resourceNames: ["etcd-coreserving-cert"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  resourceNames: ["etcd-coreserving-ca"]
-  verbs: ["get", "watch", "list"]
 ---
+# ClusterRoleBinding to bind ClusterRole for managing EtcdStorage objects to etcdproxy-controller-sa.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcdproxy-crd-clusterrolebinding
 subjects:
 - kind: ServiceAccount
-  name: etcdproxy-sa # Name is case sensitive
+  name: etcdproxy-controller-sa
   namespace: kube-apiserver-storage
 roleRef:
-  kind: ClusterRole #this must be Role or ClusterRole
-  name: etcdproxy-crd-clusterrole # this must match the name of the Role or ClusterRole you wish to bind to
+  kind: ClusterRole
+  name: etcdproxy-crd-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
+# RoleBinding to bind Role for managing resources in controller namespace to etcdproxy-controller-sa.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: etcdproxy-rolebinding
+  name: etcdproxy-controller-rolebinding
   namespace: kube-apiserver-storage
 subjects:
 - kind: ServiceAccount
-  name: etcdproxy-sa # Name is case sensitive
+  name: etcdproxy-controller-sa
   namespace: kube-apiserver-storage
 roleRef:
-  kind: Role #this must be Role or ClusterRole
-  name: etcdproxy-role # this must match the name of the Role or ClusterRole you wish to bind to
+  kind: Role
+  name: etcdproxy-controller-role
   apiGroup: rbac.authorization.k8s.io
 ---
+# EtcdStorage CRD.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -85,6 +91,8 @@ spec:
     kind: EtcdStorage
     plural: etcdstorages
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -94,6 +102,7 @@ spec:
               type: string
               maxLength: 59 # because of service name, explained above.
 ---
+# Controller deployment.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -111,7 +120,7 @@ spec:
       labels:
         controller: etcdproxy
     spec:
-      serviceAccountName: etcdproxy-sa
+      serviceAccountName: etcdproxy-controller-sa
       containers:
       - name: etcdproxy-controller
         image: xmudrii/etcdproxy-controller:latest


### PR DESCRIPTION
This PR adds manifests for deploying EtcdProxyController on cluster and a document describing what's deployed by the manifest and RBAC rules.

/cc @deads2k 