### PR TITLE
Add documentation describing required setup and how to run EtcdProxyController

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,81 @@ Implements https://groups.google.com/forum/#!msg/kubernetes-sig-api-machinery/rH
 
 ## Purpose
 
-This controller implements the `EtcdStorage` type, used to provide etcd storage for aggregated API servers.
+This controller implements the `EtcdStorage` type, used to provide etcd storage for the aggregated API servers.
 
 ## Compatibility
 
 HEAD of this repo matches versions `1.10` of `k8s.io/apiserver`, `k8s.io/apimachinery`, and `k8s.io/client-go`.
 
-## Running
+## Running controller
 
-Prerequisite: Since the sample-controller uses apps/v1 deployments, the Kubernetes cluster version should be greater than 1.9.
+There're two ways to run `EtcdProxyController`:
 
+* in-cluster, which is done by deploying [the deployment manifest, located in the `artifacts/deployment` directory](artifacts/deployment/00-etcdproxy-controller.yaml),
+* out-of-cluster, which is done by building the controller binary and running it on the local machine.
+
+Before running the controller, you need to deploy the etcd cluster. There's an example manifests along with the deploying instructions in the [`artifacts/etcd` directory](artifacts/etcd).
+
+The deployment manifest assumes etcd is available on `https://etcd-svc-1.etcd.svc:2379`. This can be configured by updating the [`00-etcdproxy-controller.yaml` manifest](artifacts/deployment/00-etcdproxy-controller.yaml).
+
+When running out-of-cluster, the etcd URL can be changed using the `etcd-core-url` flag.
+
+### Providing the core etcd client certificates to the controller
+
+When deploying the core etcd using the provided manifests, you can deploy the client certificates using the `etcd-client-certs.yaml` manifest. [The README of `artifacts/etcd`](artifacts/etcd) contains more details about deploying the client certificates.
+
+If you're deploying etcd using another method, the `EtcdProxyController` requires you to provide it the CA certificate (`ca.pem`) as a ConfigMap,
+and the client certificate (`client.pem`) and key (`client-key.pem`) as a Secret, in the controller namespace:
+
+* The ConfigMap is by default called `etcd-coreserving-ca` (can be configured using the `--etcd-core-ca-configmap` flag),
+* The Secret is by default called `etcd-coreserving-cert` (can be configured using the `--etcd-core-ca-secret` flag).
+
+The ConfigMap and Secret can be created using the following `kubectl` commands:
 ```
-# assumes you have a working kubeconfig, not required if operating in-cluster
-$ go run *.go -kubeconfig=$HOME/.kube/config
+kubectl create configmap etcd-coreserving-ca --from-file=ca.pem -n kube-apiserver-storage
+kubectl create secret generic etcd-coreserving-cert --from-file=client.pem --from-file=client-key.pem -n kube-apiserver-storage
+```
 
-# create a CustomResourceDefinition
-$ kubectl create -f artifacts/examples/etcdstorage-crd.yaml
+### Running out-of-cluster
 
-# create a custom resource of type Foo
-$ kubectl create -f artifacts/examples/etcdstorage-cr.yaml
+Before running the controller out-of-cluster you need to create the etcd proxy namespace and the EtcdStorage CRD.
 
-# check deployments created through the custom resource
-$ kubectl get deployments
+The etcd proxy namespace is by default called `kube-apiserver-storage` (can be configured using `--namespace` flag),
+and we can create it using `kubectl`:
+```
+kubectl create namespace kube-apiserver-storage
+```
+
+The EtcdStorage CRD can be deployed using the manifest located in [`artifacts/etcdstorage` directory](artifacts/etcdstorage):
+```
+kubectl create -f artifcats/etcdstorage/crd.yaml
+```
+
+To build the controller, you need the [Go toolchain installed and configured](https://golang.org/doc/install).
+Then, you can build the controller using the `compile` Make target, which compiles the controller and creates a binary in the `./bin` directory:
+```
+make compile
+```
+
+To run the controller, you need to provide it a path to `kubeconfig` and the URL of the core etcd:
+```
+./bin/etcdproxy-controller --kubeconfig ~/.kube/config --etcd-core-url https://etcd-svc-1.etcd.svc:2379
+```
+
+## Creating etcd instances for aggregated API servers
+
+To create an etcd instance for your aggregated API server, you need to deploy an `EtcdStorage` manifest.
+The sample manifest is located in the `artifacts/etcdstorage` directory, and you can deploy it with `kubectl`, such as:
+```
+kubectl create -f artifacts/etcdstorage/example-etcdstorage.yaml
+```
+
+Once the `EtcdStorage` is deployed, the controller creates the ReplicaSet for EtcdProxy pods, and a Service to expose the pods.
+
+Then, you can use the etcd for your aggregated API server, over the URL such as `http://etcd-<name-of-etcdstorage-object>.kube-apiserver-storage.svc:2379`.
+In case of the sample manifest, etcd is available on `http://etcd-etcd-name.kube-apiserver-storage.svc:2379`.
+
+You can check what resources are created in the controller namespace with the following `kubectl` command:
+```
+kubectl get all -n kube-apiserver-storage
 ```

--- a/artifacts/deployment/README.md
+++ b/artifacts/deployment/README.md
@@ -21,7 +21,7 @@ This directory contains manifest for deploying the `EtcdProxy` Controller in the
 The deployment manifest assumes you have the core `etcd` deployed and exposed on `https://etcd-svc-1.etcd.svc:2379`.
 The URL can be changed by modifying the `--etcd-core-url` flag in the `00-etcdproxy-controller.yaml` file.
 
-There is an example `etcd` deploymend manifest located in the [`artifacts/etcd`](https://github.com/xmudrii/etcdproxy-controller/tree/master/artifacts/etcd) directory.
+There is an example `etcd` deploymend manifest located in the [`artifacts/etcd`](../etcd) directory.
 
 ## Deploying certificates
 

--- a/artifacts/etcd/README.md
+++ b/artifacts/etcd/README.md
@@ -1,6 +1,6 @@
 # Core etcd
 
-The `etcd.yaml` manifest can be used to deploy the core etcd in the `etcd` namespace (created by the `etcd.yaml` manifest), running on the port `:2379`, and exposed on `https://etcd-svc-1.etcd.svc:2379`. The manifest deploys the CA certificate in the `etcd-coreserving-ca` ConfigMap, and the server certificate and key in the `etcd-coreserver-cert` Secret.
+The `etcd.yaml` manifest can be used to deploy the core etcd in the `etcd` namespace (created by the manifest), running on the port `:2379`, and exposed on `https://etcd-svc-1.etcd.svc:2379`. The manifest deploys the CA certificate in the `etcd-coreserving-ca` ConfigMap, and the server certificate and key in the `etcd-coreserver-cert` Secret.
 
 For the improved security, it's recommended to create a new pair of certificates and to replace existing ones in the `etcd.yaml` manifest. You generate certificates using [`cfssl`](https://github.com/cloudflare/cfssl). You can learn how to generate certificates using `cfssl` in the [Generate self-signed certificates](https://coreos.com/os/docs/latest/generate-self-signed-certificates.html) portion of the CoreOS documentation.
 
@@ -11,3 +11,22 @@ The client certificates for accessing the core `etcd` can be deployed using the 
 The client certificates and key, and CA certificate, are needed by the EtcdProxy Controller, for the `etcd` proxy pods to access the core etcd.
 
 The manifest deploys the `etcd-coreserving-ca` ConfigMap with the CA certificate, and the `etcd-coreserving-cert` Secret with the client certificate and key, both in the controller namespace (`kube-apiserver-storage`).
+
+For improved security, it's recommended to generate new pair of certificates, for example by using the `cfssl` tool.
+
+## Deploying the core etcd
+
+This directory contains manifests for deploying and exposing the core etcd.
+
+The `etcd.yaml` manifest file deploys a single-node etcd cluster and the `etcd-svc-1` Service. It can be deployed using `kubectl` such as:
+```
+kubectl create -f etcd.yaml
+```
+
+The `etcd-client-certs.yaml` manifest deploys the client certificates needed by clients (e.g. EtcdProxyController) to access the core etcd.
+
+The ConfigMap called `etcd-coreserving-ca` contains the CA certificate, and the Secret called `etcd-coreserving-cert`, contains the client certificate and key.
+By default, those resources are deployed in the namespace called `kube-apiserver-storage`.
+
+Once `etcd` is deployed, you can use it to access `etcd` over the URL such as `https://etcd-svc-1.etcd.svc:2379`, where `etcd-svc-1` is the name
+of the service, and `etcd` is the name of the namespace where the core `etcd` is deployed.


### PR DESCRIPTION
This PR adds documentation describing setup needed to run EtcdProxyController and how to run EtcdProxyController. The documentation also covers how to run the core etcd using the provided sample manifests.