### PR TITLE
Remove Config function in favor of Validate and ApplyTo

### DIFF
--- a/pkg/cmd/controller/start.go
+++ b/pkg/cmd/controller/start.go
@@ -23,8 +23,13 @@ func NewCommandEtcdProxyControllerStart(stopCh <-chan struct{}) *cobra.Command {
 		Short: "Start EtcdProxyController",
 		Long:  "Start EtcdProxyController",
 		Run: func(c *cobra.Command, args []string) {
-			cfg, err := o.Config()
-			if err != nil {
+			cfg := &etcdproxy.EtcdProxyControllerConfig{}
+
+			if err := o.Validate(); err != nil {
+				glog.Fatal(err)
+			}
+
+			if err := o.ApplyTo(cfg); err != nil {
 				glog.Fatal(err)
 			}
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -114,16 +114,3 @@ func (c *CoreEtcdOptions) Validate() error {
 
 	return utilerrors.NewAggregate(errors)
 }
-
-func (e *EtcdProxyControllerOptions) Config() (*etcdproxy.EtcdProxyControllerConfig, error) {
-	if err := e.Validate(); err != nil {
-		return nil, err
-	}
-
-	c := &etcdproxy.EtcdProxyControllerConfig{}
-	if err := e.ApplyTo(c); err != nil {
-		return nil, err
-	}
-
-	return c, nil
-}


### PR DESCRIPTION
This PR removes Config function in the `options` package in favor of Validate and ApplyTo functions, as proposed by [this comment](https://github.com/xmudrii/etcdproxy-controller/pull/15#discussion_r195544539).