### PR TITLE
Use double-slash prefixed flags in controller deployment manifest

### DIFF
--- a/artifacts/deployment/etcdproxy-controller.yaml
+++ b/artifacts/deployment/etcdproxy-controller.yaml
@@ -126,5 +126,5 @@ spec:
         image: xmudrii/etcdproxy-controller:latest
         command:
           - /etcdproxy-controller
-          - "-etcd-core-url=https://etcd-svc-1.etcd.svc:2379"
+          - "--etcd-core-url=https://etcd-svc-1.etcd.svc:2379"
         imagePullPolicy: Always


### PR DESCRIPTION
In #15 we moved from Go flags to Cobra flags, which use double-slash prefix instead of single-slash. This PR updates the deployment manifest to reflect changes made in #15.