### PR TITLE
Allow multiple core etcd endpoints to be specified

### DIFF
--- a/pkg/controller/etcdproxy/config.go
+++ b/pkg/controller/etcdproxy/config.go
@@ -21,8 +21,8 @@ type EtcdProxyControllerConfig struct {
 
 // CoreEtcdConfig type is used to wire the core etcd information used by controller to create ReplicaSets.
 type CoreEtcdConfig struct {
-	// URL is the address of the core etcd.
-	URL string
+	// URLs contains the core etcd addresses.
+	URLs []string
 
 	// CAConfigMapName is the name of the ConfigMap in the controller namespace where CA certificates for
 	// the core etcd are stored.

--- a/pkg/controller/etcdproxy/etcdproxy_controller.go
+++ b/pkg/controller/etcdproxy/etcdproxy_controller.go
@@ -291,8 +291,8 @@ func (c *EtcdProxyController) syncHandler(key string) error {
 	if errors.IsNotFound(err) {
 		replicaset, err = c.kubeclientset.AppsV1().ReplicaSets(c.config.ControllerNamespace).Create(newReplicaSet(
 			etcdstorage, c.config.ControllerNamespace, etcdstorage.Name,
-			c.config.ProxyImage, c.config.CoreEtcd.URL,
-			c.config.CoreEtcd.CAConfigMapName, c.config.CoreEtcd.CertSecretName))
+			c.config.ProxyImage, c.config.CoreEtcd.CAConfigMapName, c.config.CoreEtcd.CertSecretName,
+			c.config.CoreEtcd.URLs))
 	}
 
 	// If an error occurs during Get/Create, we'll requeue the item so we can

--- a/pkg/controller/etcdproxy/etcdproxy_controller_test.go
+++ b/pkg/controller/etcdproxy/etcdproxy_controller_test.go
@@ -37,7 +37,7 @@ func TestSyncHandler(t *testing.T) {
 			startingEtcdStorage: etcdStorage("test-1"),
 			etcdProxyConfig: &EtcdProxyControllerConfig{
 				CoreEtcd: &CoreEtcdConfig{
-					URL:             "https://test.etcd.svc:2379",
+					URLs:            []string{"https://test.etcd.svc:2379"},
 					CAConfigMapName: "etcd-coreserving-ca",
 					CertSecretName:  "etcd-coreserving-cert",
 				},
@@ -52,7 +52,7 @@ func TestSyncHandler(t *testing.T) {
 			startingEtcdStorage: etcdStorage("test-2"),
 			etcdProxyConfig: &EtcdProxyControllerConfig{
 				CoreEtcd: &CoreEtcdConfig{
-					URL:             "https://test.etcd.svc:2379",
+					URLs:            []string{"https://test.etcd.svc:2379"},
 					CAConfigMapName: "etcd-coreserving-ca",
 					CertSecretName:  "etcd-coreserving-cert",
 				},

--- a/pkg/controller/etcdproxy/helpers.go
+++ b/pkg/controller/etcdproxy/helpers.go
@@ -2,6 +2,7 @@ package etcdproxy
 
 import (
 	"fmt"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,7 +17,7 @@ import (
 // the EtcdStorage resource that 'owns' it.
 func newReplicaSet(etcdstorage *etcdstoragev1alpha1.EtcdStorage,
 	etcdControllerNamespace, etcdProxyNamespace, etcdProxyImage,
-	etcdCoreUrl, etcdCoreCAConfigMapName, etcdCoreCertSecretName string) *appsv1.ReplicaSet {
+	etcdCoreCAConfigMapName, etcdCoreCertSecretName string, etcdCoreURLs []string) *appsv1.ReplicaSet {
 	labels := map[string]string{
 		"controller": "epc",
 	}
@@ -46,7 +47,7 @@ func newReplicaSet(etcdstorage *etcdstoragev1alpha1.EtcdStorage,
 							Image:   etcdProxyImage,
 							Command: []string{"/usr/local/bin/etcd", "grpc-proxy", "start"},
 							Args: []string{
-								flagfromString("endpoints", etcdCoreUrl),
+								flagfromString("endpoints", strings.Join(etcdCoreURLs, ",")),
 								flagfromString("namespace", "/"+etcdProxyNamespace+"/"),
 								"--listen-addr=0.0.0.0:2379",
 								"--cacert=/etc/certs/ca/ca.pem",
@@ -100,8 +101,7 @@ func newReplicaSet(etcdstorage *etcdstoragev1alpha1.EtcdStorage,
 	}
 }
 
-func newService(etcdstorage *etcdstoragev1alpha1.EtcdStorage,
-	etcdControllerNamespace string) *corev1.Service {
+func newService(etcdstorage *etcdstoragev1alpha1.EtcdStorage, etcdControllerNamespace string) *corev1.Service {
 	labels := map[string]string{
 		"controller": "epc",
 	}


### PR DESCRIPTION
This PR changes Options and Config structs, and the `--etcd-core-url` flag to allow specifying multiple core etcd endpoints.

The `etcd grpc-proxy start` command, which we use to start the etcd proxy, already supports specifying multiple etcd endpoints, so this is a simple change to our spec and flag parsing.

The E2E tests are passing with this build:
```
...
* Deploying EtcdStorage object and verifying deployed resources.
=== RUN   TestDeployEtcdStorage
=== RUN   TestDeployEtcdStorage/test_simple_etcdstorage_creation
--- PASS: TestDeployEtcdStorage (3.53s)
    --- PASS: TestDeployEtcdStorage/test_simple_etcdstorage_creation (3.53s)
PASS
ok  	github.com/xmudrii/etcdproxy-controller/test/e2e	3.548s
- EtcdStorage tests completed successfully!

- Testing sample-apiserver deployment:
...
* Waiting for API server to become ready
* Creating a sample Flunder resource.
flunder.wardle.k8s.io "my-first-flunder" created

- All tests passed successfully!
...
```

Closes #26 
/cc @deads2k 