### PR TITLE
Prevent UpdateStatus loops

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -288,6 +288,7 @@
 [[projects]]
   name = "k8s.io/apimachinery"
   packages = [
+    "pkg/api/equality",
     "pkg/api/errors",
     "pkg/api/meta",
     "pkg/api/resource",
@@ -555,6 +556,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "270325a5d19766b2844371cf48da5a64bc0e54a5bb699078d000a3fceaffa455"
+  inputs-digest = "e96f6bc89cde66b3dc87a1d4fa905d62e5499676f508c48718062f759c934225"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/controller/etcdproxy/etcdproxy_controller.go
+++ b/pkg/controller/etcdproxy/etcdproxy_controller.go
@@ -283,7 +283,7 @@ func (c *EtcdProxyController) syncHandler(key string) error {
 	// Otherwise, the controller ends up in the ReplicaSet recreation loop until GC doesn't
 	// delete the EtcdStorage resource.
 	if !etcdstorage.DeletionTimestamp.IsZero() {
-		c.recorder.Event(etcdstorage, corev1.EventTypeNormal, Terminating, MessageResourceTerminating)
+		glog.V(2).Infof("EtcdStorage %s is being terminated.", etcdstorage.Name)
 		return nil
 	}
 

--- a/pkg/controller/etcdproxy/etcdproxy_controller.go
+++ b/pkg/controller/etcdproxy/etcdproxy_controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/glog"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -32,13 +33,16 @@ import (
 const httpUserAgentName = "etcdproxy-controller"
 
 const (
-	// SuccessSynced is used as part of the Event 'reason' when a EtcdStorage is synced
+	// SuccessSynced is used as part of the Event 'reason' when an EtcdStorage is synced.
 	SuccessSynced = "Synced"
+	// Terminating is used as part of the Event 'reason' when an EtcdStorage resource is being deleted (deletion
+	// timestamp is set).
+	Terminating = "Terminating"
 	// ResourceReclaimed is used as part of the Event 'reason' when a replicaset or service already exists
 	// and EtcdStorage reclaims it.
 	ResourceReclaimed = "ResourceReclaimed"
 
-	// ErrResourceReclaimed is used as port of the Event 'reason' when reclaiming a resource fails.
+	// ErrResourceReclaimed is used as part of the Event 'reason' when reclaiming a resource fails.
 	ErrResourceReclaimed = "ErrResourceReclaimed"
 	// ErrUnknown is used as part of the Event 'reason' when a EtcdStorage fails
 	// to get, create, or update resource.
@@ -47,6 +51,8 @@ const (
 	// ResourceReclaimedReason is the message used for Events when a resource
 	// fails to sync due to a ReplicaSet already existing
 	ResourceReclaimedReason = "Resource %q already exists and is set to be managed by EtcdStorage"
+	// ResourceTerminatingReason is the message used for Events when a EtcdStorage is terminating.
+	MessageResourceTerminating = "EtcdStorage is being terminated"
 	// MessageResourceSynced is the message used for an Event fired when a EtcdStorage
 	// is synced successfully
 	MessageResourceSynced = "EtcdStorage synced successfully"
@@ -273,6 +279,14 @@ func (c *EtcdProxyController) syncHandler(key string) error {
 		return err
 	}
 
+	// This prevents syncHandler to continue in case an EtcdStorage resource is being deleted.
+	// Otherwise, the controller ends up in the ReplicaSet recreation loop until GC doesn't
+	// delete the EtcdStorage resource.
+	if !etcdstorage.DeletionTimestamp.IsZero() {
+		c.recorder.Event(etcdstorage, corev1.EventTypeNormal, Terminating, MessageResourceTerminating)
+		return nil
+	}
+
 	replicaset, err := c.replicasetsLister.ReplicaSets(c.config.ControllerNamespace).Get(replicaSetName(etcdstorage))
 	if errors.IsNotFound(err) {
 		replicaset, err = c.kubeclientset.AppsV1().ReplicaSets(c.config.ControllerNamespace).Create(newReplicaSet(
@@ -358,6 +372,13 @@ func (c *EtcdProxyController) updateEtcdStorageStatus(etcdstorage *etcdstoragev1
 	condition etcdstoragev1alpha1.EtcdStorageCondition) (*etcdstoragev1alpha1.EtcdStorage, error) {
 	etcdstorageCopy := etcdstorage.DeepCopy()
 	etcdstoragev1alpha1.SetEtcdStorageCondition(etcdstorageCopy, condition)
+
+	// We're not updating the EtcdStorage resource if there are no Status changes between new and old objects
+	// in order to prevent Update loops.
+	if equality.Semantic.DeepEqual(etcdstorageCopy.Status, etcdstorage.Status) {
+		return etcdstorage, nil
+	}
+
 	etcdstorageCopy, err := c.etcdProxyClient.EtcdV1alpha1().EtcdStorages().UpdateStatus(etcdstorageCopy)
 	return etcdstorageCopy, err
 }

--- a/vendor/k8s.io/apimachinery/pkg/api/equality/BUILD
+++ b/vendor/k8s.io/apimachinery/pkg/api/equality/BUILD
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["semantic.go"],
+    importpath = "k8s.io/apimachinery/pkg/api/equality",
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/apimachinery/pkg/api/equality/semantic.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/equality/semantic.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package equality
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Semantic can do semantic deep equality checks for api objects.
+// Example: apiequality.Semantic.DeepEqual(aPod, aPodWithNonNilButEmptyMaps) == true
+var Semantic = conversion.EqualitiesOrDie(
+	func(a, b resource.Quantity) bool {
+		// Ignore formatting, only care that numeric value stayed the same.
+		// TODO: if we decide it's important, it should be safe to start comparing the format.
+		//
+		// Uninitialized quantities are equivalent to 0 quantities.
+		return a.Cmp(b) == 0
+	},
+	func(a, b metav1.MicroTime) bool {
+		return a.UTC() == b.UTC()
+	},
+	func(a, b metav1.Time) bool {
+		return a.UTC() == b.UTC()
+	},
+	func(a, b labels.Selector) bool {
+		return a.String() == b.String()
+	},
+	func(a, b fields.Selector) bool {
+		return a.String() == b.String()
+	},
+)


### PR DESCRIPTION
There is a regression introduced in #14 that made controller to go into infinite UpdateStatus loop.

When we create a EtcdStorage object, we create a ReplicaSet and a Service, and then [set the Deployed condition](https://github.com/xmudrii/etcdproxy-controller/blob/d6bab32a70325d70c05b18b1d7149cb100adaffe/pkg/controller/etcdproxy/etcdproxy_controller.go#L342).

Then, it calls [the `updateEtcdStorageStatus` function](https://github.com/xmudrii/etcdproxy-controller/blob/d6bab32a70325d70c05b18b1d7149cb100adaffe/pkg/controller/etcdproxy/etcdproxy_controller.go#L357), which invokes [the `UpdateStatus` function](https://github.com/xmudrii/etcdproxy-controller/blob/d6bab32a70325d70c05b18b1d7149cb100adaffe/pkg/controller/etcdproxy/etcdproxy_controller.go#L361).

However, the `UpdateStatus` function invokes `UpdateFunc` method, which requeues the EtcdStorage object.

It goes in the `syncHandler` again, but as we're not checking is there any difference, we're updating the status again, using the `UpdateStatus` function, which invokes `UpdateFunc` method again, and we go into the infinite loop.

That causes the controller to misbehave, as well as causes the performance degradation.

In logs that looks like:
```
...
I0628 17:51:50.408695   32568 etcdproxy_controller.go:240] Successfully synced 'etcd-name'
I0628 17:51:50.408749   32568 event.go:218] Event(v1.ObjectReference{Kind:"EtcdStorage", Namespace:"", Name:"etcd-name", UID:"76da23f5-7aea-11e8-8dec-7085c249f105", APIVersion:"etcd.xmudrii.com", ResourceVersion:"7967", FieldPath:""}): type: 'Normal' reason: 'Synced' EtcdStorage synced successfully
I0628 17:51:50.608408   32568 etcdproxy_controller.go:240] Successfully synced 'etcd-name'
I0628 17:51:50.608452   32568 event.go:218] Event(v1.ObjectReference{Kind:"EtcdStorage", Namespace:"", Name:"etcd-name", UID:"76da23f5-7aea-11e8-8dec-7085c249f105", APIVersion:"etcd.xmudrii.com", ResourceVersion:"7969", FieldPath:""}): type: 'Normal' reason: 'Synced' EtcdStorage synced successfully
I0628 17:51:50.808702   32568 etcdproxy_controller.go:240] Successfully synced 'etcd-name'
I0628 17:51:50.808784   32568 event.go:218] Event(v1.ObjectReference{Kind:"EtcdStorage", Namespace:"", Name:"etcd-name", UID:"76da23f5-7aea-11e8-8dec-7085c249f105", APIVersion:"etcd.xmudrii.com", ResourceVersion:"7971", FieldPath:""}): type: 'Normal' reason: 'Synced' EtcdStorage synced successfully
...
```

This PR adds the check before applying the Deployed condition. If condition is already present and true, we're not updating the EtcdStorage object.

/cc @deads2k @sttts 