### PR TITLE
Upgrade etcd for etcd proxy pods to v3.3.8

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -46,7 +46,7 @@ func NewEtcdProxyControllerOptions() *EtcdProxyControllerOptions {
 		CoreEtcd:            NewCoreEtcdOptions(),
 		ControllerNamespace: "kube-apiserver-storage",
 		KubeconfigPath:      "",
-		ProxyImage:          "quay.io/coreos/etcd:v3.2.18",
+		ProxyImage:          "quay.io/coreos/etcd:v3.3.8",
 	}
 }
 


### PR DESCRIPTION
This PR upgrades Etcd for etcd proxy pods to v3.3.8 from v3.2.18.

This is because v3.2 doesn't have flags for specifying CA certificate and server certificate and key. The v3.3 introduces several new flags, including `--trusted-ca-file`, `--cert-file`, `--key-file`, that we'll use to handle SSL for the etcd proxy.

The E2E tests are passing with this build.

Required by #35 
/cc @deads2k @sttts 