### PR TITLE
Enable E2E tests in Travis-CI using Minikube and Kubernetes v1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,14 @@ language: go
 go:
   - '1.10.x'
 
+services:
+  - docker
+
 env:
   global:
+    - KUBERNETES_VERSION=v1.10.0
     # Move Kubernetes config files to the appropriate place and adjust permissions.
     - CHANGE_MINIKUBE_NONE_USER=true
-    - KUBERNETES_VERSION=v1.10.0
 
 jobs:
   include:
@@ -20,20 +23,23 @@ jobs:
     - stage: Tests
       script: make test-ci
 
-#    - stage: E2E Tests
-#      script: make test-e2e
-#      before_script:
-#        # Download kubectl, which is a requirement for using minikube and running e2e tests.
-#        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-#        # Download minikube.
-#        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-#        # Start minikube.
-#        - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=${KUBERNETES_VERSION}
-#        # Update the kubeconfig to use the minikube cluster.
-#        - minikube update-context
-#        # Wait for Kubernetes to be up and ready.
-#        # TODO: Check for /healthz
-#        - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+    - stage: E2E Tests
+      script: make test-e2e
+      before_script:
+        # Make root rshared in order to fix kube-dns problems.
+        - sudo mount --make-rshared /
+        # Download kubectl, which is a requirement for using minikube and running e2e tests.
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        # Download minikube.
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        # Start minikube.
+        - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=${KUBERNETES_VERSION} --feature-gates=CustomResourceSubresources=true
+        # Update the kubeconfig to use the minikube cluster.
+        - minikube update-context
+        # Wait for Kubernetes to be up and ready.
+        - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+        # Wait for kube-dns to become ready.
+        - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
 
 notifications:
   email: false

--- a/artifacts/deployment/00-etcdproxy-controller.yaml
+++ b/artifacts/deployment/00-etcdproxy-controller.yaml
@@ -127,4 +127,4 @@ spec:
         command:
           - /etcdproxy-controller
           - "--etcd-core-url=https://etcd-svc-1.etcd.svc:2379"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -15,6 +15,11 @@ echo -e 'kubernetes version:\t' $(kubectl version -o json | jq .serverVersion.gi
 echo -e 'etcdproxy version:\t' $(git rev-parse --verify HEAD)
 echo ''
 
+# Tag xmudrii/etcdproxy-controller:latest Docker image.
+echo '- Tagging etcdproxy-controller Docker image.'
+docker build -t xmudrii/etcdproxy-controller:latest .
+echo ''
+
 # Deploying prerequisites
 echo '- Deploying the core etcd'
 kubectl create -f ${SCRIPT_ROOT}/artifacts/etcd/etcd.yaml
@@ -51,6 +56,10 @@ APISERVICE_STATUS=$(kubectl get apiservice v1alpha1.wardle.k8s.io -o jsonpath="{
 while [ "$APISERVICE_STATUS" != "True" ]
 do
     APISERVICE_STATUS=$(kubectl get apiservice v1alpha1.wardle.k8s.io -o jsonpath="{.status.conditions[0].status}")
+done
+until kubectl get --raw /apis/wardle.k8s.io/v1alpha1
+do
+    sleep 0.5
 done
 
 echo '* Creating a sample Flunder resource.'


### PR DESCRIPTION
This PR enables E2E tests in Travis-CI using Minikube v0.26 to create Kubernetes v1.10.0 cluster, with CRD Status Subresources enabled.

This Minikube set up is based on [this one from Lili](https://github.com/LiliC/travis-minikube/tree/minikube-26-kube-1.10), but with root mounted as `rshared` and CRD Status Subresources enabled.

The latest supported Kubernetes version for Minikube is v1.10.0. The reason why we can't go with newer versions is that the `localkube` bootstrapper used by Minikube only works with Kubernetes up to v1.10.0. Newer version are available with `kubeadm` bootstrapper, but it doesn't work with CI as it depends on `systemd` and `systemd-containers`. It is the same reason why we can't use `kube-spawn` or other similar solutions.

CRD Status Subresource are Alpha in this version, and must be enabled using the appropriate Feature Gate. I don't think we're missing any feature from newer versions, and E2E tests are passing, so I think it's okay to go with this version for now.

I also tried kubeadm-dind, and compared to it, Minikube is much faster (it takes about 2 minutes, while dind takes at least 6-7 mintutes), as well as it's more stable.

/cc @sttts