### PR TITLE
Add note about GKE permissions note needed to deploy the controller and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ HEAD of this repo matches versions `1.10` of `k8s.io/apiserver`, `k8s.io/apimach
 
 ## Running controller
 
-There're two ways to run `EtcdProxyController`:
+There are two ways to run `EtcdProxyController`:
 
 * in-cluster, which is done by deploying [the deployment manifest, located in the `artifacts/deployment` directory](artifacts/deployment/00-etcdproxy-controller.yaml),
 * out-of-cluster, which is done by building the controller binary and running it on the local machine.

--- a/artifacts/deployment/README.md
+++ b/artifacts/deployment/README.md
@@ -1,6 +1,6 @@
 # Deploying `EtcdProxy` Controller
 
-This directory contains manifest for deploying the `EtcdProxy` Controller in the cluster. The manifest deploys the following resources:
+This directory contains the `00-etcdproxy-controller.yaml` manifest, used for deploying the `EtcdProxy` Controller in the cluster. The manifest deploys the following resources:
 
 * **namespace/kube-apiserver-storage** - namespace for the EtcdProxyController to lives in,
 
@@ -15,6 +15,14 @@ This directory contains manifest for deploying the `EtcdProxy` Controller in the
 
 * **customresourcedefinition/etcdstorages.etcd.xmudrii.com** - CRD defining the EtcdStorage type for managing etcd proxies,
 * **deployment/etcdproxy-controller-deployment** - Controller Deployment.
+
+Before deploying the EtcdProxy controller on GKE, it's required to grant your user the ability to create and manage RBAC roles in the cluster,
+which can be done by executing the following command:
+```
+kubectl create clusterrolebinding cluster-admin-binding \
+--clusterrole cluster-admin --user <your-email-address>
+```
+More about the Role-Based Access Control in GKE can be found in [Google Cloud documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
 ## Deploying the core `etcd`
 


### PR DESCRIPTION
Addresses part of #31 by adding a note to docs about needed GKE permissions to create RBAC roles. The typo mentioned by @deads2k in #16 is fixed as well https://github.com/xmudrii/etcdproxy-controller/pull/16#discussion_r200658941.

/cc @deads2k @sttts 