### PR TITLE
Enable RBAC in Travis-CI Minikube cluster and fix APIServer ConfigMap/Secret Role APIGroup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,13 @@ jobs:
         # Download minikube.
         - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
         # Start minikube.
-        - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=${KUBERNETES_VERSION} --feature-gates=CustomResourceSubresources=true
+        - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=${KUBERNETES_VERSION} --feature-gates=CustomResourceSubresources=true --extra-config=apiserver.Authorization.Mode=RBAC
         # Update the kubeconfig to use the minikube cluster.
         - minikube update-context
         # Wait for Kubernetes to be up and ready.
         - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+        # Ensure default ServiceAccount is a cluster-admin, as a workaround required for kube-dns when running with RBAC enabled.
+        - kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
         # Wait for kube-dns to become ready.
         - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
 

--- a/artifacts/deployment/02-sample-apiserver-certs.yaml
+++ b/artifacts/deployment/02-sample-apiserver-certs.yaml
@@ -32,11 +32,11 @@ metadata:
   name: etcdproxy-manage-certs
   namespace: k8s-sample-apiserver
 rules:
-- apiGroups: ["v1"]
+- apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "update", "patch"]
   resourceNames: ["etcd-client-cert"]
-- apiGroups: ["v1"]
+- apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "update", "patch"]
   resourceNames: ["etcd-serving-ca"]


### PR DESCRIPTION
The [`etcdproxy-manage-certs` Role](https://github.com/xmudrii/etcdproxy-controller/blob/09288c937bfb36bc581ed4267e900c2a98eaac7f/artifacts/deployment/02-sample-apiserver-certs.yaml#L35) which ensures the EtcdProxyController ServiceAccount can get and write to ConfigMaps and Secrets in the APIServer namespace, has specified APIGroup `v1`, which is incorrect, as roles for resources in the Core API should not specify any APIGroup.

That caused controller to misbehave when deployed in-cluster once we merged #35.

The E2E tests in Travis-CI have not caught this issue, as RBAC is disabled by default in Minikube. This PR also enables RBAC. In order to enable RBAC, we have to make `default` ServiceAccount a `cluster-admin` or otherwise the kube-dns fails.

Relevant issue kubernetes/minikube#1722