### PR TITLE
Make etcdproxy containers use etcd 3.2.24 instead of 3.3.8

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -53,7 +53,7 @@ func NewEtcdProxyControllerOptions() *EtcdProxyControllerOptions {
 		CoreEtcd:            NewCoreEtcdOptions(),
 		ControllerNamespace: "kube-apiserver-storage",
 		KubeconfigPath:      "",
-		ProxyImage:          "quay.io/coreos/etcd:v3.3.8",
+		ProxyImage:          "quay.io/coreos/etcd:v3.2.24",
 	}
 }
 


### PR DESCRIPTION
We're currently using etcd 3.3.8, as etcd 3.2 hasn't include flags required to run etcd grpc-proxy with SSL enabled. The etcd version change was introduced in #38.

In https://github.com/coreos/etcd/pull/9894 the required flags to allow running proxy with SSL were added. 

Two days ago, the new 3.2 release has been published and it includes required flags, so we can switch back to etcd 3.2.

