### PR TITLE
Add liveness probe to the etcdproxy deployment and raise number of replicas to 3

### DIFF
--- a/pkg/controller/etcdproxy/helpers.go
+++ b/pkg/controller/etcdproxy/helpers.go
@@ -24,7 +24,7 @@ func newDeployment(etcdstorage *etcdstoragev1alpha1.EtcdStorage,
 	labels := map[string]string{
 		"apiserver": etcdstorage.Name,
 	}
-	replicas := int32(1)
+	replicas := int32(3)
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -88,6 +88,22 @@ func newDeployment(etcdstorage *etcdstoragev1alpha1.EtcdStorage,
 									MountPath: "/etc/etcdproxy-certs/server",
 									ReadOnly:  true,
 								},
+							},
+							LivenessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/bin/sh",
+											"-ec",
+											"ETCDCTL_API=3 etcdctl get foo",
+										},
+									},
+								},
+								InitialDelaySeconds: 10,
+								PeriodSeconds:       30,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+								TimeoutSeconds:      10,
 							},
 						},
 					},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -53,7 +53,7 @@ func TestDeployEtcdStorage(t *testing.T) {
 				},
 			},
 			expectedDeploymentName: "etcd-es-test-1",
-			expectedReplicas:       int32(1),
+			expectedReplicas:       int32(3),
 			expectedServiceName:    "etcd-es-test-1",
 		},
 		{
@@ -68,7 +68,7 @@ func TestDeployEtcdStorage(t *testing.T) {
 				},
 			},
 			expectedDeploymentName: "etcd-es-test-2",
-			expectedReplicas:       int32(1),
+			expectedReplicas:       int32(3),
 			expectedServiceName:    "etcd-es-test-2",
 		},
 	}


### PR DESCRIPTION
Previously, we were running EtcdProxy ReplicaSet with 1 replica. Later on, in #58, we switched to Deployments instead of ReplicaSets, so we can utilize rolling updates.

The reason we need to raise number of replica is that when we renew server certificate or client CA bundle, we'll need to restart etcdproxy pod. If we run only one etcdproxy pod, restarting it will cause total outage until it doesn't recover.

To prevent this, we will run 3 pods, and then use rolling update when updating the certificates, to make sure we have at least one or two pods running at the same time.

The reason we need to add liveness probe is that if the core etcd fails, etcdproxy will not notice it until it receives the next request. It would be nice to make etcdproxy aware of the core etcd outages, so it can restart before user/API server tries to use it.
With the liveness probe, etcdproxy will query the core etcd each 30 seconds. In case of the core etcd goes down, the etcdproxy pods will be restarted automatically.

I found that this liveness probe is also used by etcd created by `etcd-operator`, so I think it is fine to use it.

Questions:
* I don't think we need readiness probe, liveness should do the job.
* Is 3 etcdproxy pods enough? Do we want 2 maybe?
* Do we want to allow operator to customize the number of etcdproxy replicas? Maybe by adding a field in the EtcdStorage Spec?

Fixes #27