### PR TITLE
Make CI use Ubuntu 16.04 and Kubernetes 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-language: go
+dist: xenial
+sudo: required
 
+language: go
 go:
   - '1.10.x'
 
@@ -8,9 +10,10 @@ services:
 
 env:
   global:
-    - KUBERNETES_VERSION=v1.10.0
     # Move Kubernetes config files to the appropriate place and adjust permissions.
     - CHANGE_MINIKUBE_NONE_USER=true
+    - KUBERNETES_VERSION=v1.12.0
+    - MINIKUBE_VERSION=v0.30.0
 
 jobs:
   include:
@@ -26,20 +29,16 @@ jobs:
     - stage: E2E Tests
       script: make test-e2e
       before_script:
-        # Make root rshared in order to fix kube-dns problems.
-        - sudo mount --make-rshared /
         # Download kubectl, which is a requirement for using minikube and running e2e tests.
         - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
         # Download minikube.
-        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
         # Start minikube.
-        - sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=${KUBERNETES_VERSION} --feature-gates=CustomResourceSubresources=true --extra-config=apiserver.Authorization.Mode=RBAC
+        - sudo minikube start --vm-driver=none --bootstrapper=kubeadm --kubernetes-version=${KUBERNETES_VERSION}
         # Update the kubeconfig to use the minikube cluster.
         - minikube update-context
         # Wait for Kubernetes to be up and ready.
         - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
-        # Ensure default ServiceAccount is a cluster-admin, as a workaround required for kube-dns when running with RBAC enabled.
-        - kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
         # Wait for kube-dns to become ready.
         - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
 


### PR DESCRIPTION
This PR updates Travis-CI pipeline to use Ubuntu 16.04 and Kuberentes 1.12.0 with Minikube 0.30.0.

This is important so we can run newer Kubernetes versions which support RBAC and CRD Subresources out of box.

Ubuntu 16.04 support for Travis-CI is still in beta and is not officially supported, but it seems to be very stable so far. I think it is okay to give it a try and test is it stable enough in our case.

Looking by performance, time needed to create a new cluster has not changed. I confirmed that image building works and that Kubernetes is using newly built image as intended.