### PR TITLE
Move to kubernetes-sigs/kind for running E2E tests in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,14 @@ sudo: required
 
 language: go
 go:
-  - '1.10.x'
+  - '1.11.x'
 
 services:
   - docker
 
 env:
   global:
-    # Move Kubernetes config files to the appropriate place and adjust permissions.
-    - CHANGE_MINIKUBE_NONE_USER=true
-    - KUBERNETES_VERSION=v1.12.0
-    - MINIKUBE_VERSION=v0.30.0
+    - KUBECTL_VERSION=v1.12.0
 
 jobs:
   include:
@@ -29,18 +26,15 @@ jobs:
     - stage: E2E Tests
       script: make test-e2e
       before_script:
-        # Download kubectl, which is a requirement for using minikube and running e2e tests.
-        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-        # Download minikube.
-        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-        # Start minikube.
-        - sudo minikube start --vm-driver=none --bootstrapper=kubeadm --kubernetes-version=${KUBERNETES_VERSION}
-        # Update the kubeconfig to use the minikube cluster.
-        - minikube update-context
-        # Wait for Kubernetes to be up and ready.
-        - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
-        # Wait for kube-dns to become ready.
-        - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
+        # Download kubectl, which is a requirement for using kind and running e2e tests.
+        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        # Download and build kind
+        - go get sigs.k8s.io/kind
+        # Start kind cluster using default settings
+        - kind create cluster
+        # Set kubeconfig environment variable
+        - export KUBECONFIG="$(kind get kubeconfig-path)"
 
 notifications:
   email: false
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,3 @@ jobs:
 
 notifications:
   email: false
-  

--- a/hack/ci-build-image.sh
+++ b/hack/ci-build-image.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
+
+IMAGE=xmudrii/etcdproxy-controller
+KIND_CLUSTER_NAME="kind-1"
+KIND_CONTAINER_NAME="${KIND_CLUSTER_NAME}-control-plane"
+
+build_image() {
+    # Switch to the root directory.
+    cd $SCRIPT_ROOT
+    
+    # Create a temporary directory to store generated Docker image.
+    TMP_DIR=$(mktemp -d)
+    IMAGE_FILE=${TMP_DIR}/etcdproxy-controller.tar.gz
+
+    # Build Docker image.
+    docker build -t "${IMAGE}":latest .
+    # Export generated Docker image to an archive.
+    docker save "${IMAGE}" -o "${IMAGE_FILE}"
+    # Copy saved archive into kind's Docker container.
+    docker cp "${IMAGE_FILE}" "${KIND_CONTAINER_NAME}":/etcdproxy-controller.tar.gz
+    # Import image into kind's Docker daemon to make it accessible to Kubernetes.
+    docker exec "${KIND_CONTAINER_NAME}" docker load -i /etcdproxy-controller.tar.gz
+
+    # Cleanup the temporary directory.
+    rm -rf "${TMP_DIR}"
+}
+
+build_image

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -17,7 +17,7 @@ echo ''
 
 # Tag xmudrii/etcdproxy-controller:latest Docker image.
 echo '- Tagging etcdproxy-controller Docker image.'
-docker build -t xmudrii/etcdproxy-controller:latest .
+${SCRIPT_ROOT}/hack/ci-build-image.sh
 echo ''
 
 # Deploying prerequisites

--- a/pkg/certs/generate.go
+++ b/pkg/certs/generate.go
@@ -27,7 +27,7 @@ func NewCACertificate(subject pkix.Name, serialNumber int64, validity metav1.Dur
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 
 	cert, err := signCertificate(caCert, caPublicKey, caCert, caPrivateKey)


### PR DESCRIPTION
This PR moves from Minikube to [`kubernetes-sigs/kind`](https://github.com/kubernetes-sigs/kind) for Travis-CI and E2E tests. Compared to Minikube, `kind` doesn't require systemd to run newer Kubernetes version, and currently runs Kubernetes 1.12 out-of-box.

Changelog:
* Travis-CI now uses Go 1.11.x instead of Go 1.10.x
* We're now using kind with Kubernetes 1.12 instead of Minikube with Kubernetes 1.10 and CRD Subresources enabled
* A script is added for building and moving `etcdproxy-controller` Docker image to the kind's container, based on the script from [the `jestack/cert-manager` repository](https://github.com/jetstack/cert-manager/blob/4ed36535e5b295a3ae5986c747088f9607b96751/hack/ci/lib/build_images.sh).
* E2E script is updated to use the new image building script instead of `docker build`

/cc @sttts for approval